### PR TITLE
Fix folia builds

### DIFF
--- a/.github/workflows/folia.yml
+++ b/.github/workflows/folia.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           sh build.sh
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: FoliaToGo
           path: Folia/build/libs/*.jar

--- a/.github/workflows/folia.yml
+++ b/.github/workflows/folia.yml
@@ -31,7 +31,7 @@ jobs:
       - name: 'Build Folia .jar'
         run: |
           sudo apt update
-          sudo apt install openjdk-19-jre-headless
+          sudo apt install default-jre
           sh build.sh
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/folia.yml
+++ b/.github/workflows/folia.yml
@@ -31,7 +31,7 @@ jobs:
       - name: 'Build Folia .jar'
         run: |
           sudo apt update
-          sudo apt install default-jre
+          sudo apt install openjdk-21-jre-headless
           sh build.sh
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/folia.yml
+++ b/.github/workflows/folia.yml
@@ -25,13 +25,15 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
 
       # Runs a set of commands using the runners shell
       - name: 'Build Folia .jar'
         run: |
-          sudo apt update
-          sudo apt install openjdk-21-jre-headless
           sh build.sh
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Uses [actions/setup-java](https://github.com/actions/setup-java) to get Java 21 instead of doing it manually.

This also fixes the build since the runner was not using the manually installed `openjdk-19-jre-headless`. It was still using Java 11 which cannot build Folia.