### PR TITLE
Fixed build errors and the path of the Jar file in the build result.

### DIFF
--- a/.github/workflows/folia.yml
+++ b/.github/workflows/folia.yml
@@ -39,4 +39,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: FoliaToGo
-          path: Folia/build/libs/*.jar
+          path: Folia/folia-server/build/libs/*.jar

--- a/build.sh
+++ b/build.sh
@@ -4,5 +4,5 @@ git clone https://github.com/PaperMC/Folia
 git config --global user.email "you@example.com"
 git config --global user.name "Your Name"
 cd Folia
-./gradlew applyPatches
-./gradlew createReobfPaperclipJar
+./gradlew applyAllPatches
+./gradlew createMojmapPaperclipJar


### PR DESCRIPTION
It seems that the build method and Jar file location have changed due to the hard fork.
This commit should make the build work again.